### PR TITLE
Improve styles of icon for instant translate

### DIFF
--- a/src/user-script/content-page.scss
+++ b/src/user-script/content-page.scss
@@ -20,14 +20,14 @@ $md-icons-font-path: "chrome-extension://__MSG_@@extension_id__/fonts/";
     @import "../components/ui/icons/material-icon";
 
     position: absolute;
+    font-size: 20px;
     font-style: normal;
     cursor: pointer;
     border-radius: 50%;
-    border: 1px solid;
+    box-shadow: 0px 0px 2px 1px black;
     color: black;
     background: white;
-    width: $iconSize;
-    height: $iconSize;
+    padding: 4px;
 
     &.isLeftTop {
       transform: translate(-100%, -100%);


### PR DESCRIPTION
Was:

![image](https://cloud.githubusercontent.com/assets/6510020/23767634/4dc49a1e-051a-11e7-8383-cb08ba16eb02.png)

Became:

![image](https://cloud.githubusercontent.com/assets/6510020/23767651/58428848-051a-11e7-8715-d3dd9e8184a9.png)
