### PR TITLE
feat: add Arabic language flag

### DIFF
--- a/src/components/select-language/select-language.tsx
+++ b/src/components/select-language/select-language.tsx
@@ -306,6 +306,7 @@ export const langToFlagIconMap: Record<string, string> = {
   "zu": "za", // Zulu (South Africa)
   "xh": "za", // Xhosa (South Africa)
   "vi": "vn", // Vietnamese
+  "ar": "sa", // Arabic
 };
 
 export function getFlagIcon(locale: string): string | undefined {


### PR DESCRIPTION
I want to thank the developers for their fantastic work on the extension. Their efforts are greatly appreciated. 👏 

* Add an Arabic flag because the current one is confusing.

Current one:
<img width="161" alt="Screenshot 2024-08-02 at 9 10 58 AM" src="https://github.com/user-attachments/assets/6c2de32d-780b-4760-964e-b55bca99bd3a">

New One:

<img width="161" alt="Screenshot 2024-08-02 at 9 13 35 AM" src="https://github.com/user-attachments/assets/996d8070-c6ce-446a-9219-0bbaf0b44015">
