### PR TITLE
feat: Add Serbian language flag for Google & Yandex

### DIFF
--- a/src/components/select-language/select-language.tsx
+++ b/src/components/select-language/select-language.tsx
@@ -307,6 +307,7 @@ export const langToFlagIconMap: Record<string, string> = {
   "xh": "za", // Xhosa (South Africa)
   "vi": "vn", // Vietnamese
   "ar": "sa", // Arabic
+  "sr": "rs", // Serbian
 };
 
 export function getFlagIcon(locale: string): string | undefined {


### PR DESCRIPTION
Hello @ixrock, I'm happy to contribute to your project.
Current Serbian flag is mapped to Suriname and I fixed it for Google and Yandex.

![Wrong flag on Google and Yandex](https://github.com/user-attachments/assets/ca39d0a5-781d-48eb-80db-2e4a62339d84)

However, for Bing, I see they have two versions of Serbian language (latin & cyrillic), and I'm not sure how to fix that. I suppose they use extended codes like `sr-Latn` & `sr-Cyrl`. Can you please check that and potentially add flags for those two as well?

![No flags on Bing](https://github.com/user-attachments/assets/ba4e50c1-67ad-405c-aa5e-cb23f2895770)
