### PR TITLE
Add latin Serbian

### DIFF
--- a/_locales/sr.ftl
+++ b/_locales/sr.ftl
@@ -1,6 +1,9 @@
 # Localization file for chrome extension
 # URL: https://chrome.google.com/webstore/detail/xtranslate/gfgpkepllngchpmcippidfhmbhlljhoo
-# Author: Radoš Milićev (https://github.com/rammba)
+# Authors:
+#				- https://github.com/Sijera
+#				- Radoš Milićev (https://github.com/rammba)
+
 -app-brand-name = XTranslate
 
 # common

--- a/_locales/sr_Latn.ftl
+++ b/_locales/sr_Latn.ftl
@@ -1,0 +1,175 @@
+# Localization file for chrome extension
+# URL: https://chrome.google.com/webstore/detail/xtranslate/gfgpkepllngchpmcippidfhmbhlljhoo
+# Author: Radoš Milićev (https://github.com/rammba)
+
+-app-brand-name = XTranslate
+
+# common
+short_description = Lako prevedite tekst na veb stranicama
+description = Prevedite tekst sa veb stranice, prilagodite izgled iskačućeg prozora i još mnogo toga.
+
+# header
+open_in_window = Otvori u zasebnom prozoru
+tab_settings = Podešavanja
+tab_theme = Iskačući prozor
+tab_text_input = Prevod
+tab_history = Istorija
+
+# settings
+setting_title_common = Opšte
+setting_title_text_input = Prevod
+setting_title_popup = Iskačući prozor
+setting_title_translator_service = Prevodilac
+settings_title_tts = Pretvaranje teksta u govor (Text-to-speech, TTS)
+settings_title_appearance = Izgled
+auto_play_tts = Automatski reprodukuj pretvaranje teksta u govor
+use_chrome_tts = Koristi Chrome mehanizam za pretvaranje teksta u govor
+use_chrome_tts_tooltip_info = Ova opcija je automatski omogućena kada prevodilac nema dostupan TTS mehanizam
+use_dark_theme = Promeni temu
+tts_default_system_voice = Podrazumevani sistemski glas
+tts_select_voice_title = Izaberi glas
+tts_play_demo_sound = Pusti demo glas
+tts_play_demo_sound_edit = Promeni tekst za zvučni demo
+import_export_settings = Import/Export podešavanja
+export_settings_button_label = Export podešavanja
+import_settings_button_label = Import podešavanja
+import_incorrect_file_format = Neispravan format (trebalo bi da bude { $fileNameJson })
+imported_setting_successful = Podešavanja sa ključem { $key } su uspešno import-ovana
+show_context_menu = Prikaži stavku u kontekstnom meniju (obavezno za *.pdf)
+display_icon_near_selection = Prikaži ikonicu za prevod pored izabranog teksta
+show_tts_icon_inside_popup = Prikaži ikonicu za pretvaranje teksta u govor
+show_next_vendor_icon_in_popup = Prikaži ikonicu sledećeg prevodioca
+show_copy_translation_icon = Prikaži ikonicu za kopiranje prevoda
+show_save_as_favorite_icon = Prikaži ikonicu za čuvanje u omiljeno
+show_close_popup_button = Prikaži ikonicu za zatvaranje iskačućeg prozora u desnom ćošku
+show_close_popup_button_title = Zatvori
+show_detected_language_block = Prikaži otkriveni jezik
+display_on_click_by_selected_text = Prikaži klikom na izabrani tekst
+display_popup_after_text_selected = Prikaži nakon izbora teksta
+display_popup_on_double_click = Prikaži dvoklikom na reč
+display_popup_on_hotkey = Prikaži pritiskom prečice
+remember_last_typed_text = Zapamti poslednji ukucani tekst
+sub_header_quick_access_hotkey = Podesi prečicu
+quick_access_configure_link = Podešavanje prečice na tastaturi za brzi pristup ovom prozoru
+swap_languages = Zameni jezike
+popup_position_title = Položaj
+popup_position_auto = Automatski (poravnato sa tekstom)
+popup_position_left_top = Gornji levi ugao
+popup_position_right_top = Gornji desni ugao
+popup_position_left_bottom = Donji levi ugao
+popup_position_right_bottom = Donji desni ugao
+translation_delay = Kašnjenje prevoda
+translation_delay_info = Ako često nailazite na blokiranje (greška 503) od Google-a ili drugih servisa, postavite veću vrednost kašnjenja
+reverse_translate_select_placeholder = Jezik za obrnuti prevod
+reverse_translate_add_action = Dodaj jezik za obrnuti prevod: { $lang } -> ? (primenljivo samo kad je "Otkrivanje jezika" uključeno)
+reverse_translate_delete_action = Obriši jezik za obrnuti prevod
+position_of_x_translate_icon = Pozicija ikonice za prevod kod odabira
+
+# theme
+popup_play_icon_title = Preslušaj
+popup_copy_translation_title = Kopiraj prevod
+popup_next_vendor_icon_title = Prevedi pomoću: { $translator }
+popup_demo_translation = Prevedeni tekst
+popup_demo_dictionary_noun = imenica
+popup_demo_dictionary_values = Reč 1, reč 2, itd.
+sub_header_background = Pozadina
+sub_header_box_shadow = Senka
+sub_header_text = Tekst
+sub_header_border = Ivica
+sub_header_box_size = Veličina okvira
+background_color = Boja
+background_linear_gradient = Linearno
+box_shadow_color = Boja
+box_shadow_inner = Unutra
+text_size = Veličina
+text_font_family = Font
+text_color = Boja
+text_shadow = Senka
+text_shadow_size = Zamagljivanje
+text_shadow_offset_x = Horizontalno odstupanje
+text_shadow_offset_y = Vertikalno odstupanje
+text_shadow_color = Boja
+border_width = Širina
+border_style = Stil
+border_color = Boja
+border_radius = Poluprečnik
+box_size_min_width = Minimilna širina
+box_size_min_height = Minimalna visina
+box_size_max_width = Maksimalna širina
+box_size_max_height = Maksimalna visina
+reset_to_default_button_text = Vrati na podrazumevano
+
+# text input
+text_field_placeholder = Započnite kucanje da biste dobili prevod
+translated_with = Prevedeno pomoću: { $translator } ({ $lang })
+translated_from = Prevedeno sa: { $lang }
+translate_also_from = Prevedi i sa
+spell_correction = Da li ste mislili: { $suggestion }?
+text_input_translation_hint = { $hotkey } za trenutni prevod, kašnjenje: { $timeout }ms
+
+# history
+history_enabled_flag = Omogućeno
+history_settings_save_words_only = Sačuvaj samo reči iz rečnika
+history_search_input_placeholder = Pretraži u istoriji
+history_clear_period_hour = Protekli sat
+history_clear_period_day = Protekli dan
+history_clear_period_month = Protekli mesec
+history_clear_period_year = Protekla godina
+history_clear_period_all = Sve
+history_button_clear = Obriši istoriju
+history_button_show_more = Prikaži više
+history_export_entries = Export-uj: { $format }
+history_import_entries = Import-uj: { $format }
+history_page_size = Veličina stranice
+history_icon_tooltip_search = Pretraga
+history_icon_tooltip_imp_exp = Import / Export
+history_icon_tooltip_settings = Podešavanja
+history_show_favorites_only = Prikaži samo omiljeno
+history_mark_as_favorite = Obeleži kao omiljeno
+history_unmark_as_favorite = Ukloni iz omiljenog
+history_import_success = Uspešno uvezenih stavki istorije: { $itemsCount }
+history_import_file_error = Greška u čitanju datoteke '{ $fileName }': { $errorInfo }
+
+# context menu
+context_menu_translate_full_page = Prevedi celu stranicu pomoću: { $translator }
+context_menu_translate_selection = Prevedi { $selection } pomoću: { $translator }
+
+# other
+share_with_friends = Ako vam se sviđa aplikacija, podelite je sa prijateljima:
+translation_data_failed = Učitavanje podataka nije uspelo
+rate_app_info1 = Uživate u korišćenju aplikacije? Ocenite nas sa 5 zvezdica!
+rate_app_info2 = To će pomoći drugim korisnicima da pronađu proširenje u Chrome veb prodavnici.
+rate_app_button = Ocenite u Chrome veb prodavnici
+rate_app_button_later = Podseti me kasnije
+deepl_get_own_key_info = Registruj se na www.deepl.com da bi dobio besplatan ključ za autentifikaciju za DeepL API
+deepl_insert_auth_key = Postavi ključ za autentifikaciju za DeepL API
+target_lang_placeholder = Ciljani jezici
+source_lang_placeholder = Izvorni jezici
+favorites_lang_title = Omiljeno
+favorites_info_tooltip = Da bi menjali omiljene jezike (lista na vrhu), koristite { $hotkey } + klik
+donate_title = Podrška developera
+donate_copy_wallet = Kopiraj adresu
+donate_description = Ako vam se sviđa aplikacija, možete donirati developerima. Hvala!
+service_unavailable = Servis nije dostupan. Probajte ponovo za 5-25 minuta. Ako se to često dešava, povećajte vrednost kašnjenja prevoda u podešavanjima.
+service_confirm_not_a_robot = Možete otići na { $link } i potvrditi da niste robot.
+
+# privacy policy
+privacy_policy_title_updated = Politika privatnosti je ažurirana
+privacy_policy_accept_terms = Prihvatite odredbe i uslove
+
+# mellowtel integration
+mellowtel_greetings = Pozdrav, prijatelju 👋
+mellowtel_text1 = Kao što verovatno znate, ovo proširenje je besplatno i dostupno svima... ali da bi nastavili, potrebno je da uradite par stvari!
+mellowtel_text2 = Nova verzija uključuje open-source { $link } biblioteku. Ova biblioteka vam omogućava da podelite nekorišćeni internet sa pouzdanim AI laboratorijama & startup-ima koji ga koriste da treniraju svoje modele.
+mellowtel_usage_title = Mellowtel koristimo za:
+mellowtel_usage1 = Praćenje prekida rada servisa
+mellowtel_usage2 = Merenje kvaliteta rada servisa
+mellowtel_usage3 = Kao developer ovog proširenja, dobijamo mali deo prihoda
+mellowtel_accept_all_info1 = Ako izaberete 'Prihvati sve', koristićemo Mellowtel API da: Dozvolimo pouzdanim partnerima da pristupe resursima na internetu rutiranjem dela njihovog saobraćaja kroz vaš čvor na mreži.
+mellowtel_accept_all_info2 = Mellowtel deli samo vaš propusni opseg. Sigurnost i privatnost su 100% garantovani i sama biblioteka je open source kako bi svi mogli da je vide.
+mellowtel_regulation1 = Ne prikuplja, deli niti prodaje privatne informacije (čak ni anonimne podatke).
+mellowtel_regulation2 = Takođe je visoko regulisano: Mellowtel komunicira sa regulatorima Chrome veb prodavnice da bi garantovao sigurno iskustvo.
+mellowtel_regulation3 = Takođe pruža i CWS regulatore sa alatima za nadgledanje i primenu usklađenosti.
+mellowtel_button_decline = Odbi opciono
+mellowtel_button_accept = Prihvati sve
+mellowtel_dialog_footer = Hvala što ste izdvojili vreme da pročitate, timovi { $devs }.

--- a/_locales/sr_Latn/messages.json
+++ b/_locales/sr_Latn/messages.json
@@ -1,0 +1,8 @@
+{
+  "short_description": {
+    "message": "Lako prevedite tekst na veb stranicama"
+  },
+  "description": {
+    "message": "Prevedite tekst sa veb stranice, prilagodite izgled iskačućeg prozora i još mnogo toga."
+  }
+}


### PR DESCRIPTION
Hello @ixrock. In #101 I mentioned latin support for Serbian, so I added it now.
Can you please tell me how should I name current Serbian (cyrillic version) files. From what I know, correct locale names should be [sr_Cyrl](https://www.localeplanet.com/icu/sr-Cyrl/index.html) and [sr_Latn](https://www.localeplanet.com/icu/sr-Latn/index.html), but maybe chrome playstore has some different identifiers? I would like to use same naming for both Serbian locales.